### PR TITLE
Add transaction history module

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -860,6 +860,15 @@ def get_monthly_summaries():
     """)
     return jsonify([dict(row) for row in cursor.fetchall()])
 
+@app.route('/api/finances/available-months', methods=['GET'])
+def get_available_months():
+    """Zwraca listę miesięcy, dla których istnieją transakcje."""
+    db = get_db()
+    cursor = db.execute(
+        "SELECT DISTINCT strftime('%Y-%m', data_transakcji) as miesiac FROM Transakcje ORDER BY miesiac DESC"
+    )
+    return jsonify([row['miesiac'] for row in cursor.fetchall()])
+
 @app.route('/api/finances/transactions', methods=['GET'])
 def get_transactions_for_month():
     """Zwraca listę transakcji dla danego miesiąca (w formacie RRRR-MM)."""

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,9 @@
         <nav>
             <button id="nav-patients-btn" class="nav-btn active">Pacjenci</button>
             <button id="nav-warehouse-btn" class="nav-btn">Magazyn</button>
-            <button id="nav-finance-btn" class="nav-btn">Finanse</button> </nav>
+            <button id="nav-finance-btn" class="nav-btn">Finanse</button>
+            <button id="nav-finance-history-btn" class="nav-btn">Historia</button>
+        </nav>
         </nav>
     </header>
 
@@ -167,8 +169,25 @@
             </section>
         </div>
 
+        <div id="finance-history-view-container" class="view-container hidden">
+            <section class="panel">
+                <h2>Historia Transakcji</h2>
+                <div class="form-row">
+                    <select id="finance-year-select"></select>
+                    <select id="finance-month-select"></select>
+                    <button id="show-history-btn">Pokaż</button>
+                </div>
+                <div id="finance-history-summary"></div>
+                <hr>
+                <table class="data-table">
+                    <thead><tr><th>Data</th><th>Pacjent</th><th>Suma</th></tr></thead>
+                    <tbody id="finance-history-table"></tbody>
+                </table>
+            </section>
+        </div>
 
-    </main>
+
+        </main>
 
     <div id="swap-aparat-modal" class="modal-backdrop hidden">
         <div class="modal-content">

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -177,6 +177,10 @@ function getMonthlySummaries() {
   return fetchAPI('/finances/monthly-summaries');
 }
 
+function getAvailableMonths() {
+  return fetchAPI('/finances/available-months');
+}
+
 function getTransactionsForMonth(month) { // format RRRR-MM
   return fetchAPI(`/finances/transactions?month=${month}`);
 }


### PR DESCRIPTION
## Summary
- provide backend endpoint to list months with transactions
- expose `getAvailableMonths` helper in frontend API
- add finance history view markup and navigation button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863186abb3483249423b1d9dbb385ec