### PR TITLE
Add monthly transaction summary endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -868,13 +868,23 @@ def get_transactions_for_month():
         return jsonify({'message': 'Brak parametru miesiąca.'}), 400
 
     db = get_db()
-    cursor = db.execute("""
+    cursor = db.execute(
+        """
         SELECT transakcja_id, data_transakcji, pacjent_imie, pacjent_nazwisko, kwota_laczna
         FROM Transakcje
         WHERE strftime('%Y-%m', data_transakcji) = ?
         ORDER BY data_transakcji DESC
-    """, (month,))
-    return jsonify([dict(row) for row in cursor.fetchall()])
+        """,
+        (month,)
+    )
+
+    summary_cursor = db.execute(
+        "SELECT SUM(kwota_laczna) as total FROM Transakcje WHERE strftime('%Y-%m', data_transakcji) = ?",
+        (month,)
+    )
+    total = summary_cursor.fetchone()["total"] or 0.0
+
+    return jsonify({"transactions": [dict(row) for row in cursor.fetchall()], "summary": {"total": total}})
 
 @app.route('/api/finances/transactions/<int:transaction_id>', methods=['GET'])
 def get_transaction_details(transaction_id):


### PR DESCRIPTION
## Summary
- extend `get_transactions_for_month` API to also return monthly summary

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68631f7340388324917c689030bbc206