### PR TITLE
Add cancel-modal handler

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -76,6 +76,13 @@ const showAddComplaintFormBtn = document.getElementById('show-add-complaint-form
 const addComplaintFormContainer = document.getElementById('add-complaint-form-container');
 const addComplaintForm = document.getElementById('add-complaint-form');
 const cancelAddComplaintBtn = document.getElementById('cancel-add-complaint-btn');
+  // Ustawiamy zamykanie wszystkich modali przez przyciski "Anuluj"
+  document.querySelectorAll('.btn-cancel-modal').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const backdrop = btn.closest('.modal-backdrop');
+      if (backdrop) backdrop.classList.add('hidden');
+    });
+  });
 
 
   // === ZMIENNE STANU APLIKACJI ===


### PR DESCRIPTION
## Summary
- close modals by wiring all `.btn-cancel-modal` buttons inside DOMContentLoaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863289cd1948324b4bd348dd3c066fa