### PR TITLE
Fix cancel in quick-sale modal

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -307,7 +307,7 @@
 
             <div class="form-actions">
                 <button type="submit" class="btn-success">Zatwierdź sprzedaż</button>
-                <button type="button" class="btn-cancel-modal">Anuluj</button>
+                <button type="button" id="cancel-quick-sale-btn" class="btn-cancel-modal">Anuluj</button>
             </div>
         </form>
     </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -52,6 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
 const addBatteriesForm = document.getElementById('add-batteries-form');
 const sellBatteryModal = document.getElementById('quick-sale-modal');
 const sellBatteryForm = document.getElementById('quick-sale-form');
+const cancelQuickSaleBtn = document.getElementById('cancel-quick-sale-btn');
 const navFinanceBtn = document.getElementById('nav-finance-btn');
 const financeViewContainer = document.getElementById('finance-view-container');
 const financeMonthSelector = document.getElementById('finance-month-selector');
@@ -519,6 +520,11 @@ if (e.target.name === 'pesel' && e.target.value.length === 11) {
       deliveryModal.classList.remove('hidden');
   });
   cancelDeliveryBtn.addEventListener('click', () => deliveryModal.classList.add('hidden'));
+  cancelQuickSaleBtn.addEventListener('click', () => {
+      sellBatteryModal.classList.add('hidden');
+      batterySaleInputs.classList.add('hidden');
+      genericSaleInputs.classList.add('hidden');
+  });
   addDeliveryItemBtn.addEventListener('click', createDeliveryRow);
 
   navFinanceBtn.addEventListener('click', showFinanceView);


### PR DESCRIPTION
## Summary
- add missing cancel button id on quick-sale modal
- hide quick-sale modal and related sections when pressing cancel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632ce08c6483249c8c0f3a09bdb48f