### PR TITLE
Add missing setActiveNav helper

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -139,10 +139,16 @@ const cancelAddComplaintBtn = document.getElementById('cancel-add-complaint-btn'
       });
   }
 
-  function hideAllMainViews() {
-      [patientsViewContainer, warehouseViewContainer, financeViewContainer, financeHistoryViewContainer].forEach(v => v.classList.add('hidden'));
-      [navPatientsBtn, navWarehouseBtn, navFinanceBtn, navFinanceHistoryBtn].forEach(btn => btn.classList.remove('active'));
-  }
+function hideAllMainViews() {
+    [patientsViewContainer, warehouseViewContainer, financeViewContainer, financeHistoryViewContainer].forEach(v => v.classList.add('hidden'));
+    [navPatientsBtn, navWarehouseBtn, navFinanceBtn, navFinanceHistoryBtn].forEach(btn => btn.classList.remove('active'));
+}
+
+function setActiveNav(button) {
+    [navPatientsBtn, navWarehouseBtn, navFinanceBtn, navFinanceHistoryBtn]
+        .forEach(btn => btn.classList.remove('active'));
+    if (button) button.classList.add('active');
+}
 
   // === FUNKCJE DO ZARZĄDZANIA WIDOKAMI ===
   function showPatientsView() {


### PR DESCRIPTION
## Summary
- add `setActiveNav` function to manage active navigation state
- keep calling helper in `showFinanceView` and `showFinanceHistoryView`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863af51326c8324af114fe502f467fa