### PR TITLE
Implement side-specific headphones

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,6 +64,10 @@
                         <div class="form-row">
                             <select name="sluchawka" id="sluchawka-select" required><option value="">Wybierz słuchawkę...</option></select>
                         </div>
+                        <div class="form-row hidden" id="ear-side-row">
+                            <label><input type="radio" name="ear_side" value="prawa" checked> Prawy</label>
+                            <label><input type="radio" name="ear_side" value="lewa"> Lewy</label>
+                        </div>
                     </div>
                     <hr>
                     <h3>Wnioski</h3>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -100,8 +100,8 @@ function swapAparat(patientId, swapData) { // Przyjmuje teraz jeden obiekt z dan
   });
 }
 
-function getSluchawkiOptions(producent) {
-  return fetchAPI(`/sluchawki-options/${producent}`);
+async function getSluchawkiOptions(producent) {
+  return await fetchAPI(`/sluchawki-options/${encodeURIComponent(producent)}`);
 }
 function swapSluchawki(patientId, newSluchawkaId) {
   return fetchAPI(`/patients/${patientId}/swap-sluchawki`, {


### PR DESCRIPTION
## Summary
- group headphones by side in the backend API
- support new Prawa/Lewa data when creating a patient
- adapt frontend API wrapper
- add ear-side radio group for single devices
- adjust frontend logic for new headphone pairing

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866c202d5c88324b73f8bbb6a247244