### PR TITLE
Support side IDs in headphone swap forms

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -103,11 +103,11 @@ function swapAparat(patientId, swapData) { // Przyjmuje teraz jeden obiekt z dan
 async function getSluchawkiOptions(producent) {
   return await fetchAPI(`/sluchawki-options/${encodeURIComponent(producent)}`);
 }
-function swapSluchawki(patientId, newSluchawkaId) {
+function swapSluchawki(patientId, sluchawkiData) {
   return fetchAPI(`/patients/${patientId}/swap-sluchawki`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ new_sluchawka_id: newSluchawkaId })
+      body: JSON.stringify(sluchawkiData)
   });
 }
 


### PR DESCRIPTION
## Summary
- track how many earphones a patient has
- include right and left earphone IDs when swapping devices
- require both earphone IDs when two are in use
- adjust API call to accept new payload

## Testing
- `node -c frontend/js/app.js && node -c frontend/js/api.js`
- `python3 -m py_compile $(git ls-files '*.py') && echo 'py ok'`


------
https://chatgpt.com/codex/tasks/task_e_6866e0f7c6808324a3d3a05b8307c50e